### PR TITLE
build: Let's start with a basic ci config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js 18
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - run: npm ci
+    - run: npm test

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,70 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/README.md
+++ b/README.md
@@ -1,26 +1,13 @@
 # <img src="https://raw.githubusercontent.com/cmoulliard/litoria/master/templates/image/litoria-chloris.jpg"> litoria
 
-[![Coverage Status](https://coveralls.io/repos/github/cmoulliard/litoria/badge.svg?branch=master)](https://coveralls.io/github/cmoulliard/litoria?branch=master)
-[![Build Status](https://travis-ci.org/cmoulliard/litoria.svg?branch=master)](https://travis-ci.org/cmoulliard/litoria) 
+![CI](https://github.com/ch007/litoria/workflows/ci/badge.svg)
 [![Known Vulnerabilities](https://snyk.io/test/npm/litoria/badge.svg)](https://snyk.io/test/npm/litoria) 
-[![dependencies Status](https://david-dm.org/cmoulliard/litoria/status.svg)](https://david-dm.org/cmoulliard/litoria)
-
-[![NPM](https://nodei.co/npm/litoria.png)](https://npmjs.org/package/litoria)
-
 
 Command Line Tool to manage asciidoc projet (create, watch content), convert adoc into html, pdf & epub3 for doc, reports, revealjs slideshow, hands on lab & more
 
-|                 | Project Info  |
-| --------------- | ------------- |
-| License:        | Apache-2.0  |
-| Build:          | make  |
-| Documentation:  | N/A  |
-| Issue tracker:  | https://github.com/cmoulliard/litoria/issues  |
-| Engines:        | Node.js 6.x, 7.x, 8.x
-
-## Installation
-
-    $ npm install litoria -g
+```
+npm install litoria -g
+```
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "yamljs": "^0.2.8"
   },
   "scripts": {
+    "pretest": "eslint bin/*.js lib/*.js test/*.js",
     "test": "tape test/*.js | tap-spec",
-    "lint": "eslint bin/*.js lib/*.js test/*.js",
     "coverage": "istanbul cover tape test/log-test.js tape test/render.js",
     "release": "release-it"
   },


### PR DESCRIPTION
This commit also:

* Adds a built-in github config SAST feature with codeQL
* Removes the lint script and use the pretest built-in npm script, so that, the lint will run automatically for each npm test.
* A bit of cleanup on README.md
* CI badge

related to #30 